### PR TITLE
Added archive property and ability to edit agree button text

### DIFF
--- a/code/admin/UserAgreementAdmin.php
+++ b/code/admin/UserAgreementAdmin.php
@@ -13,4 +13,66 @@ class UserAgreementAdmin extends ModelAdmin {
 	private static $url_segment = 'user-agreements';
 	private static $menu_title = "User Agreements";
 	
+	public function getEditForm($id = null, $fields = null) {
+		$form = parent::getEditForm($id, $fields);
+		
+		/**
+		 * In the instance that the editing results in the UserAgreement switching between GridField's, we need to
+		 * load all agreements into both GridFields to permit the Save action to succeed.
+		 * (ie. the archive boolean is toggled)
+		 * Use the EditForm action to detect when editing vs viewing
+		 */
+		$action = $this->request->param('Action');
+		if ($action && $action == 'EditForm') {
+			$archived = UserAgreement::get();
+			$liveAgreements = $archived;
+		} else {
+			$archived = UserAgreement::get()->filter('Archived',true);
+			$liveAgreements = UserAgreement::get()->filter('Archived',false);
+		}
+		
+		
+		// Show Archived agreements separate to current agreements
+		$fieldName = 'ArchivedAgreements';
+
+		// Archived Agreements GridField Config
+		$config = new GridFieldConfig_Base();
+		$config->addComponent(new GridFieldEditButton());
+		$config->addComponent(new GridFieldDetailForm());
+		$config->addComponent(new GridFieldDeleteAction());
+		$config->addComponent(new GridFieldExportButton());
+		$config->addComponent(new GridFieldPrintButton());
+
+		$config->getComponentByType('GridFieldPaginator')->setItemsPerPage(5);
+
+		if($archived->count()) {
+			$formFieldArchive = GridField::create(
+				$fieldName,
+				_t(
+					'UserAgreements.ArchivedAgreements',
+					'Archived Agreements'
+					),
+				$archived,
+				$config
+			);
+
+			$formFieldArchive->setForm($form);
+			$form->Fields()->insertAfter($formFieldArchive, 'UserAgreement');
+		}
+		
+		// Omit Archived Agreements from main gridfield
+		$grid = $form->Fields()->dataFieldByName('UserAgreement');
+		if ($grid) {		
+			$grid->setList($liveAgreements);
+			$grid->setTitle(
+				_t(
+					'UserAgreements.CurrentAgreements',
+					'Current Agreements'
+					)
+			);
+		}
+		
+		return $form;
+	}
+	
 }

--- a/code/dataobjects/UserAgreement.php
+++ b/code/dataobjects/UserAgreement.php
@@ -16,9 +16,15 @@ class UserAgreement extends DataObject {
 		'Title' 	=> 'Varchar',
 		'Content' 	=> 'HTMLText',
 		'Type'		=> 'enum("Every Login, Once Only","Once Only")',
-		'Sort'		=> 'Int'
+		'Sort'		=> 'Int',
+		'AgreeText' => 'HTMLText',
+		'Archived'	=> 'Boolean'
 	);
 
+	private static $defaults = array(
+		'AgreeText' => 'I Agree to the terms and conditions'
+	);
+	
 	private static $has_one = array(
 		'Group' => 'Group'
 	);
@@ -36,7 +42,10 @@ class UserAgreement extends DataObject {
 		$fields->addFieldToTab('Root.Main', new TextField('Title'), 'GroupID');
 		$fields->addFieldToTab('Root.Main', new DropdownField('Type', 'Type', $this->dbObject('Type')->EnumValues(), $this->Type));
 		$fields->addFieldToTab('Root.Main', new TextField('Sort'));
+		$fields->addFieldToTab('Root.Main', new CheckboxField('Archived'));
 		$fields->addFieldToTab('Root.Main', new HTMLEditorField('Content'));
+		$fields->addFieldToTab('Root.Main', new HTMLEditorField('AgreeText'));
+		
 		return $fields;
 	}
 	

--- a/code/extensions/UserAgreementMember.php
+++ b/code/extensions/UserAgreementMember.php
@@ -38,12 +38,12 @@ class UserAgreementMember extends DataExtension {
 	 **/
 	public function unsignedAgreements() {
 		// are there any required agreements for this users groups?
-		$groups 	= $this->owner->Groups();
-		$groupIDs 	= implode(',', $groups->getIdList());
+		$groupIDs 	= $this->owner->Groups()->getIdList();
 		$agreementsRemaining = new ArrayList();
 		
-		$requiredAgreements = $groupIDs ? DataObject::get('UserAgreement', "GroupID IN ($groupIDs)") : null;
-				
+		$requiredAgreements = $groupIDs ? UserAgreement::get()->filter('Archived',false)->filterAny('GroupID', $groupIDs) : null;
+		$this->owner->extend('updateRequiredAgreements', $requiredAgreements);
+
 		// collect agreements to be signed - checking agreement type (one off vs session)
 		if ($requiredAgreements) {
 			//Flush the component cache - which causes the First Agreement for each Member to be shown twice on the first occurrence

--- a/code/pages/UserAgreementPage.php
+++ b/code/pages/UserAgreementPage.php
@@ -116,7 +116,7 @@ class UserAgreementPage_Controller extends Page_Controller {
      */
 	public function Form(){
 		$fields 	= new FieldList(array(
-			new CheckboxField('Agree', 'I Agree to the terms and conditions'),
+			new CheckboxField('Agree', $this->getAgreement()->AgreeText),
 			new HiddenField('AgreementID', 'AgreementID', $this->getAgreement()->ID)
 		));
         $validator 	= new RequiredFields('Agree');

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "sheadawson/silverstripe-useragreement",
+    "type": "silverstripe-module",
+    "description": "Make users sign a T&C agreement before using the website or application",
+    "keywords": [
+        "silverstripe",
+        "agreement",
+        "terms",
+        "conditions"
+    ],
+    "license": "BSD-3-Clause",
+    "authors": [
+        {
+            "name": "Shea Dawson",
+            "email": "shea@livesource.co.nz"
+        }
+    ],
+    "require": {
+		"silverstripe/framework": "~3.1",
+		"silverstripe/cms": "~3.1"
+    },
+    "support": {
+        "issues": "https://github.com/sheadawson/silverstripe-useragreement/issues"
+    },
+    "extra": {
+        "installer-name": "useragreement"
+    },
+    "homepage": "https://github.com/sheadawson/silverstripe-useragreement"
+}


### PR DESCRIPTION
User Agreements can now be flagged as archived, which puts them in to a separate gridfield in model admin away from the current agreements. Results in a nicer display when historical records of signatures needs to be kept at all times.

The agree button text is now also customisable also.